### PR TITLE
Fixes missing utils reference

### DIFF
--- a/src/scripts/ui/bottom.lua
+++ b/src/scripts/ui/bottom.lua
@@ -640,6 +640,7 @@ registerNamedEventHandler("BatUI", "status.panels.sleep", "BatUI.event.updatedTi
 end)
 
 registerNamedEventHandler("BatUI", "status.playerUpdated", "BatUI.event.playerUpdated", function(_, stats)
+    local utils = BatUI.utils
     local player = BatUI.player
     local p = BatUI.bottom.status.panels
     for _, stat in ipairs(stats) do


### PR DESCRIPTION
After removing the script-wide `local utils = BatUI.utils` to avoid loading order issues, the event handler still depended on that reference. By making the reference local within the handler, the issue is solved.